### PR TITLE
chore: caching GET requests

### DIFF
--- a/ui/src/lib/components/Preferences.svelte
+++ b/ui/src/lib/components/Preferences.svelte
@@ -9,12 +9,13 @@
 	import { onMount } from 'svelte';
 
 	const defaultPref: { [key: string]: any } = {
-		version: 3,
+		version: 4,
 		loadParentInfo: false,
 		paginationSizeUi: 20,
 		paginationSizeApi: 1000,
 		showPluginOrder: false,
-		useNewSearch: false
+		useNewSearch: false,
+		useEphemeralGetRequestsCache: true
 	};
 
 	const localCacheKey = 'preferences';

--- a/ui/src/lib/components/Preferences.svelte
+++ b/ui/src/lib/components/Preferences.svelte
@@ -15,7 +15,7 @@
 		paginationSizeApi: 1000,
 		showPluginOrder: false,
 		useNewSearch: false,
-		useEphemeralGetRequestsCache: true
+		useEphemeralGetRequestsCache: true,
 	};
 
 	const localCacheKey = 'preferences';

--- a/ui/src/routes/entities/+page.svelte
+++ b/ui/src/routes/entities/+page.svelte
@@ -6,7 +6,7 @@
 	import { triggerPageUpdate } from '$lib/stores';
 	import { staticConfig } from '$lib/config';
 	import ArrayWrap from '$lib/components/ArrayWrap.svelte';
-	import { apiService } from '$lib/requests';
+	import { apiService, requestsCacheMap, type ResWrapped } from '$lib/requests';
 	import { onMount } from 'svelte';
 	import { page } from '$app/stores';
 	import { kongEntities } from '$lib/config';
@@ -74,13 +74,25 @@
 				}
 				await delay(paginationAwaitBetweenPages);
 			}
+			// dataplanes don't have a page of their own.
+			// populating the cache to fake as if the request went through
+			if (kongEntity.apiPath === 'clustering/data-planes') {
+				for (const dp of data) {
+					const res: ResWrapped<any, any> = {
+						code: 200,
+						ok: true,
+						data: dp
+					};
+					requestsCacheMap[`/dataplanes/${dp.id}`] = res;
+				}
+			}
 			triggerPageUpdate.set(entity + DateTime.now().toMillis());
 			if (isRefresh) {
 				infoToast('refresh finished!');
 			}
 		} catch (error: any) {
-			console.log(error);
-			addToast({ message: `Failed fetching the ${entity}. ${error.message ? error.message : ''}` });
+			console.error(error);
+			addToast({ message: `Failed fetching ${entity}. ${error.message ? error.message : ''}` });
 		}
 	}
 </script>


### PR DESCRIPTION
a map is used to cache GET requests.
the key is the URL (including any pagination tokens), the value is a fully valid response object, just like it would be returned from a real call.
the cache is gone once the page is closed/refreshed.

```ts
let cache: {[key:string]: any} = {}

async function requestWithResponseBodyCached<ResType, ErrType = void>(
	url: string,
	method: string = 'GET',
	body?: object,
	headers?: Record<string, string>
): Promise<ResWrapped<ResType, ErrType>> {
	if(method == 'GET' && get(preferences.useEphemeralGetRequestsCache))
	{
		if(cache[url])
		{
			console.log(`[GET] cache hit. Total cache keys: ${Object.keys(cache).length}`)
			return cache[url]
		}
		const res = await requestWithResponseBody(url, method, body, headers)
		if(res.ok)
		{
			cache[url] = res
		}
	}
	return requestWithResponseBody(url, method, body, headers)
}
```

enabled by default, to disable:  on the preferences page set `useEphemeralGetRequestsCache` to `false`

with a little trick, consisting of populating the cache with the right keys, the dataplanes become displayable. 

- closes: https://github.com/DanielRailean/bananaui/issues/44