### PR TITLE
chore: spring tweaks

### DIFF
--- a/ui/dockerfile
+++ b/ui/dockerfile
@@ -8,9 +8,9 @@ COPY . .
 
 RUN npm install -g pnpm@latest-10
 
-ARG build_prefix
+ARG SVELTE_BUILD_PREFIX
 
-ENV SVELTE_BUILD_PREFIX=$build_prefix
+ENV SVELTE_BUILD_PREFIX=$SVELTE_BUILD_PREFIX
 
 # clean install all dependencies
 RUN pnpm install

--- a/ui/src/lib/components/AddEditEntity.svelte
+++ b/ui/src/lib/components/AddEditEntity.svelte
@@ -10,8 +10,9 @@
 	import { addToast, errorToast, infoToast } from '$lib/toastStore';
 	import { FloppyDiskAltOutline, LinkOutline, PaletteOutline } from 'flowbite-svelte-icons';
 	import { base } from '$app/paths';
-	import { kongEntities } from '$lib/config';
 	import { delay } from '$lib/util';
+	import { get } from 'svelte/store';
+	import { preferences } from '$lib/stores';
 
 	let entity: IKongEntity | undefined;
 
@@ -53,7 +54,7 @@
 		let type = query.get('type');
 		pathPrefix = query.get('prefix') ?? '';
 		if (type) {
-			entity = kongEntities.find((i) => i.name == type);
+			entity = get(preferences.kongEntities).find((i) => i.name == type);
 		}
 		if (!entity) {
 			errorToast(`entity named ${type} not found!`);

--- a/ui/src/lib/components/AddEditEntity.svelte
+++ b/ui/src/lib/components/AddEditEntity.svelte
@@ -317,7 +317,7 @@
 
 <div class="dark:border-stone-700">
 	<div class="editor dark:bg-[#1E2021] w-full min-h-[30vh] line-numbers">
-		<pre class="language-json"><code bind:this={editorSyntax}></code></pre>
+		<pre class="language-json dark:bg-zinc-900"><code class="dark:bg-zinc-900" bind:this={editorSyntax}></code></pre>
 		<textarea
 			bind:this={editorWindow}
 			spellcheck="false"
@@ -412,10 +412,5 @@
 	pre {
 		padding: 10px;
 		padding-left: 75px;
-	}
-
-	code,
-	pre {
-		@apply dark:bg-zinc-900 bg-stone-800;
 	}
 </style>

--- a/ui/src/lib/components/ArrayWrap.svelte
+++ b/ui/src/lib/components/ArrayWrap.svelte
@@ -14,7 +14,7 @@
 	import Toggle from './Toggle.svelte';
 	import { get, writable, type Writable } from 'svelte/store';
 	import { ChevronLeftOutline, ChevronRightOutline } from 'flowbite-svelte-icons';
-	import { preferences, triggerPageUpdate } from '$lib/stores';
+	import { preferences } from '$lib/stores';
 	import { Button } from 'flowbite-svelte';
 	import { dump } from 'js-yaml';
 

--- a/ui/src/lib/components/ArrayWrap.svelte
+++ b/ui/src/lib/components/ArrayWrap.svelte
@@ -17,6 +17,7 @@
 	import { preferences } from '$lib/stores';
 	import { Button } from 'flowbite-svelte';
 	import { dump } from 'js-yaml';
+	import { page } from '$app/stores';
 
 	let loadParentName = preferences?.loadParentInfo;
 	let useNewSearch = preferences?.useNewSearch;
@@ -136,8 +137,8 @@
 
 	// this is to handle initial store event
 	function updateEventOnTrigger(v: any[]) {
-		console.log(`page update triggered by data change items no: ${v.length}`);
-		updateEvent('trigger update');
+		console.log(`page update requested by data change items no: ${v.length}`);
+		updateEvent('data change');
 	}
 
 	function updateEvent(caller = '') {
@@ -162,6 +163,11 @@
 		calculatePagination();
 		updateDisplayedFields();
 	}
+
+	// TODO maybe a config param for this
+	// page.subscribe(v=> {
+	// 	searchText = ""
+	// })
 
 	function sort(arr: any[], caller = '') {
 		console.log(`sort called by '${caller}'`);

--- a/ui/src/lib/components/ArrayWrap.svelte
+++ b/ui/src/lib/components/ArrayWrap.svelte
@@ -5,7 +5,7 @@
 	import { onDestroy, onMount } from 'svelte';
 	import { DateTime } from 'luxon';
 	import { CaretDownOutline, FileCopyOutline, TrashBinOutline } from 'flowbite-svelte-icons';
-	import { dateFields, kongEntities, yamlDumpOptions } from '$lib/config';
+	import { dateFields, yamlDumpOptions } from '$lib/config';
 	import { apiService, clearCache } from '$lib/requests';
 	import { addToast, confirmToast, errorToast, infoToast } from '$lib/toastStore';
 	import { createEventDispatcher } from 'svelte';
@@ -925,7 +925,7 @@
 												{:else}
 													{item[field]}
 												{/if}
-											{:else if item[field] && Object.keys(item[field]).includes('id') && kongEntities.find((i) => i.apiPath == `${field}s`)}
+											{:else if item[field] && Object.keys(item[field]).includes('id') && get(preferences.kongEntities).find((i) => i.apiPath == `${field}s`)}
 												<!-- svelte-ignore a11y-no-static-element-interactions -->
 												<div
 													class="px-2 py-1 m-2 dark:shadow-slate-800 shadow rounded"

--- a/ui/src/lib/components/ArrayWrap.svelte
+++ b/ui/src/lib/components/ArrayWrap.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import Link from './Link.svelte';
-	import { capitalizeFirstLetter, delay, writeToClipboard } from '$lib/util';
+	import { capitalizeFirstLetter, debouncedCall, delay, writeToClipboard } from '$lib/util';
 	import { goto } from '$app/navigation';
 	import { onDestroy, onMount } from 'svelte';
 	import { DateTime } from 'luxon';
@@ -65,38 +65,23 @@
 		intervalsIterable = intervalsIterable.slice(0, intervals);
 	}
 
-	let timeout: number | undefined = undefined;
-	function copyItemSingleDoubleClick(format: "yaml" | "json", data: any) {
-		data.enabledWritable = undefined;
-		if (timeout) {
-			clearTimeout(timeout);
-			timeout = undefined;
+	function copyYamlOrJson(format: 'yaml' | 'json', data: any) {
+		if (Array.isArray(data)) {
+			data.forEach((el) => (el.enabledWritable = undefined));
 		}
-		timeout = setTimeout(() => {
-			copyYamlOrJson(format, data)
-		}, 510);
-		// setTimeout(() => {
-		// 	if (!doubleTriggered) {
-		// 		writeToClipboard(JSON.stringify(data, undefined, 2), ` JSON`);
-		// 	} else if (isDouble) {
-		// 		writeToClipboard(dump(data, yamlDumpOptions), ' YAML');
-		// 		doubleTriggered = false;
-		// 	}
-		// }, 550);
+		if (Object.keys(data).length > 0 && typeof data == 'object') {
+			data.enabledWritable = undefined;
+		}
+		if (format == 'yaml') {
+			writeToClipboard(dump(data, yamlDumpOptions), ' YAML');
+		}
+		if (format == 'json') {
+			copy(data);
+		}
 	}
 
-	let doubleTriggered = false;
-	function handleCopyWithDebounce(format: 'yaml' | 'json', isDouble: boolean) {
-		setTimeout(() => {
-			if (!doubleTriggered) {
-				handleCopy(format);
-			} else if (isDouble) {
-				handleCopy(format);
-				doubleTriggered = false;
-			}
-		}, 550);
-	}
-	function handleCopy(format: 'yaml' | 'json') {
+	let debouncedCopy = debouncedCall(copyYamlOrJson, 510);
+	let debouncedCopyAllConfirm = debouncedCall((format: 'yaml' | 'json') => {
 		const conf = confirm(
 			`confirm ${format.toUpperCase()} copy of ${filteredData.length} entities?`
 		);
@@ -107,17 +92,21 @@
 			i.enabledWritable = undefined;
 			return i;
 		});
-		copyYamlOrJson(format, data)
-	}
+		copyYamlOrJson(format, data);
+	}, 510);
 
-	function copyYamlOrJson(format: 'yaml' | 'json', data: any) {
-		if (format == 'yaml') {
-			writeToClipboard(dump(data, yamlDumpOptions), ' YAML');
+	let updateSearchParamWithDebounce = debouncedCall((map: { [key: string]: string }) => {
+		const url = new URL(window.location.toString());
+		for (const [key, val] of Object.entries(map)) {
+			if (val.length > 0) {
+				url.searchParams.set(key, val);
+			} else {
+				url.searchParams.delete(key);
+			}
 		}
-		if (format == 'json') {
-			copy(data);
-		}
-	}
+
+		history.pushState(null, '', url);
+	}, 550);
 
 	calculatePagination();
 
@@ -272,32 +261,6 @@
 			return true;
 		}
 		return false;
-	}
-
-	let searchDebounce: number | undefined = undefined;
-	// time after which the search will be written to the url query if unmodified
-	let debounceTimeoutMs = 550;
-	function updateSearchParamWithDebounce() {
-		if (searchDebounce) {
-			clearTimeout(searchDebounce);
-			searchDebounce = undefined;
-		}
-		searchDebounce = setTimeout(updateSearchQueryParams, debounceTimeoutMs, { search: searchText });
-	}
-	onDestroy(() => {
-		clearTimeout(searchDebounce);
-	});
-	function updateSearchQueryParams(map: { [key: string]: string }) {
-		const url = new URL(window.location.toString());
-		for (const [key, val] of Object.entries(map)) {
-			if (val.length > 0) {
-				url.searchParams.set(key, val);
-			} else {
-				url.searchParams.delete(key);
-			}
-		}
-
-		history.pushState(null, '', url);
 	}
 	// {
 	// [and inside here]
@@ -561,6 +524,12 @@
 		dispatch('refresh');
 	}
 	let bulkUpdateOpened = false;
+
+	onDestroy(() => {
+		updateSearchParamWithDebounce.cancel();
+		debouncedCopy.cancel();
+		debouncedCopyAllConfirm.cancel();
+	});
 </script>
 
 <div class="w-full text-sm text-left rtl:text-right text-stone-800 font-light dark:text-stone-300">
@@ -580,7 +549,7 @@
 				}}
 				on:input={() => {
 					console.log(searchText);
-					updateSearchParamWithDebounce();
+					updateSearchParamWithDebounce({ search: searchText });
 					search();
 				}}
 				title="Searches the JSON representation for the given text. &#013; &#013;Logical 'AND' is supported using the '&&' operator.&#013;Ex: 'host && /path'&#013&#013;For arrays, the .len syntax is supported, to assert it's length.&#013;Ex: tags.len == 2; tags.len != 3"
@@ -602,7 +571,7 @@
 			<select
 				bind:value={sortByField}
 				on:change={() => {
-					updateSearchQueryParams({ sortBy: sortByField });
+					updateSearchParamWithDebounce({ sortBy: sortByField });
 					updateEvent('select sort by');
 				}}
 				class="dark:bg-stone-700 shadow shadow-slate-600 h-6 p-0 max-w-36 pl-2 border-none rounded focus:border-none focus:[box-shadow:none]"
@@ -620,7 +589,7 @@
 				title={'Controls the sort direction, either ascending or descending'}
 				on:change={async () => {
 					sortAscending.set(!$sortAscending);
-					updateSearchQueryParams({ sortAscending: JSON.stringify(get(sortAscending)) });
+					updateSearchParamWithDebounce({ sortAscending: JSON.stringify(get(sortAscending)) });
 					updateEvent('toggle sort direction');
 				}}
 			/>
@@ -629,11 +598,10 @@
 			<button
 				title="copies all entities as JSON (sorted).&#13;Double click for YAML, single click for JSON"
 				on:click={() => {
-					handleCopyWithDebounce('json', false);
+					debouncedCopyAllConfirm('json');
 				}}
 				on:dblclick={() => {
-					doubleTriggered = true;
-					handleCopyWithDebounce('yaml', true);
+					debouncedCopyAllConfirm.flush('yaml');
 				}}
 				class="flex flex-row items-center dark:bg-stone-700 bg-stone-100 rounded p-1 pr-2 m-1"
 			>
@@ -856,11 +824,10 @@
 									title={'copy (single click for JSON, double click for YAML) ' +
 										JSON.stringify(item, undefined, 2)}
 									on:click={() => {
-										copyItemSingleDoubleClick("json", item);
+										debouncedCopy('json', item);
 									}}
 									on:dblclick={() => {
-										doubleTriggered = true;
-										copyItemSingleDoubleClick("yaml", item);
+										debouncedCopy.flush('yaml', item);
 									}}
 								>
 									<div
@@ -906,11 +873,13 @@
 														undefined,
 														2
 													)} `}
-											on:dblclick={() => {
+											on:click={() => {
 												if (field == 'name') {
 													goto(`${base}/entity?type=${type}&id=${item.id}&prefix=${pathPrefix}`);
 													return;
 												}
+											}}
+											on:dblclick={() => {
 												copy(item[field]);
 											}}
 										>
@@ -918,7 +887,7 @@
 												{item[field]}
 											{:else if typeof item[field] == 'boolean'}
 												{#if field === 'enabled'}
-													<div on:click|stopPropagation>
+													<div on:click|stopPropagation role="button" tabindex="0">
 														<label
 															class="inline-flex items-center cursor-pointer"
 															title="enable or disable"

--- a/ui/src/lib/components/ArrayWrap.svelte
+++ b/ui/src/lib/components/ArrayWrap.svelte
@@ -4,13 +4,8 @@
 	import { goto } from '$app/navigation';
 	import { onDestroy, onMount } from 'svelte';
 	import { DateTime } from 'luxon';
-	import {
-		ArrowUpRightFromSquareOutline,
-		CaretDownOutline,
-		FileCopyOutline,
-		TrashBinOutline
-	} from 'flowbite-svelte-icons';
-	import { dateFields, kongEntities } from '$lib/config';
+	import { CaretDownOutline, FileCopyOutline, TrashBinOutline } from 'flowbite-svelte-icons';
+	import { dateFields, kongEntities, yamlDumpOptions } from '$lib/config';
 	import { apiService, clearCache } from '$lib/requests';
 	import { addToast, confirmToast, errorToast, infoToast } from '$lib/toastStore';
 	import { createEventDispatcher } from 'svelte';
@@ -21,6 +16,7 @@
 	import { ChevronLeftOutline, ChevronRightOutline } from 'flowbite-svelte-icons';
 	import { preferences, triggerPageUpdate } from '$lib/stores';
 	import { Button } from 'flowbite-svelte';
+	import { dump } from 'js-yaml';
 
 	let loadParentName = preferences?.loadParentInfo;
 	let useNewSearch = preferences?.useNewSearch;
@@ -69,6 +65,36 @@
 		intervalsIterable = intervalsIterable.slice(0, intervals);
 	}
 
+	let doubleTriggered = false;
+	function handleCopyWithDebounce(format: 'yaml' | 'json', isDouble: boolean) {
+		setTimeout(() => {
+			if (!doubleTriggered) {
+				handleCopy(format);
+			} else if (isDouble) {
+				handleCopy(format);
+				doubleTriggered = false;
+			}
+		}, 550);
+	}
+	function handleCopy(format: 'yaml' | 'json') {
+		const conf = confirm(
+			`confirm ${format.toUpperCase()} copy of ${filteredData.length} entities?`
+		);
+		if (!conf) {
+			return;
+		}
+		const data = filteredData.map((i) => {
+			i.enabledWritable = undefined;
+			return i;
+		});
+		if (format == 'yaml') {
+			writeToClipboard(dump(data, yamlDumpOptions), ' YAML');
+		}
+		if (format == 'json') {
+			copy(data);
+		}
+	}
+
 	calculatePagination();
 
 	function copy(data: any) {
@@ -90,12 +116,21 @@
 				result = JSON.stringify(data[0], undefined, 2);
 			}
 		}
-		writeToClipboard(result);
+		writeToClipboard(result, ' JSON');
 	}
 	let sortByField = entity?.sortBy ?? 'updated_at';
 	let sortAscending = writable(entity?.sortAscending ?? false);
 
-	function updateEvent() {
+	// this is to handle initial store event
+	function updateEventOnTrigger(v?: string) {
+		console.log(`page update triggered : ${v}`)
+		if (v) {
+			updateEvent("trigger update");
+		}
+	}
+
+	function updateEvent(caller ="") {
+		console.log(`update called by '${caller}'`)
 		const params = new URLSearchParams(window.location.search);
 		if (searchText.length == 0) {
 			searchText = params.get('search') ?? '';
@@ -103,16 +138,18 @@
 		sortByField = params.get('sortBy') ?? sortByField;
 		sortAscending.set(params.get('sortAscending') === 'true');
 
-		// filteredData = dataRaw;
 		debounce = DateTime.now().toUnixInteger();
 		search();
+		if (get(preferences.sortSearchedItemsDuringPaginationProcess)) {
+			sort(filteredData, `update event ${type}`);
+		}
 		resetPagination();
 		calculatePagination();
-		sort(filteredData);
 		updateDisplayedFields();
 	}
 
-	function sort(arr: any[]) {
+	function sort(arr: any[], caller = '') {
+		console.log(`sort called by '${caller}'`);
 		arr.sort((a, b) => {
 			let fieldA = a[sortByField];
 			let fieldB = b[sortByField];
@@ -135,10 +172,10 @@
 		});
 	}
 
-	triggerPageUpdate.subscribe(updateEvent);
+	triggerPageUpdate.subscribe(updateEventOnTrigger);
 
 	onMount(() => {
-		updateEvent();
+		updateEvent("on mount");
 	});
 
 	async function disable(id: string, newEnabledValue: boolean) {
@@ -370,6 +407,9 @@
 	// getLogicalGroups('hello && test, no || test.len == 2 && no, yes.len != 2');
 	function search() {
 		if (searchText.length == 0) {
+			// we don't always sort on update event,
+			// because it could be searched, so we must sort when we know we're no longer searching
+			sort(dataRaw, `search ${type}`);
 			filteredData = dataRaw.map((i: any): FilteredEntity => {
 				if (i.enabled != undefined) {
 					i.enabledWritable = writable(i.enabled);
@@ -421,7 +461,6 @@
 				return true;
 			});
 		}
-		sort(filteredData);
 		resetPagination();
 		calculatePagination();
 	}
@@ -509,7 +548,11 @@
 				type="text"
 				disabled={!(dataRaw && dataRaw.length > 0)}
 				bind:value={searchText}
+				on:emptied={() => {
+					console.log('is empty');
+				}}
 				on:input={() => {
+					console.log(searchText);
 					updateSearchParamWithDebounce();
 					search();
 				}}
@@ -533,7 +576,7 @@
 				bind:value={sortByField}
 				on:change={() => {
 					updateSearchQueryParams({ sortBy: sortByField });
-					updateEvent();
+					updateEvent("select sort by");
 				}}
 				class="dark:bg-stone-700 shadow shadow-slate-600 h-6 p-0 max-w-36 pl-2 border-none rounded focus:border-none focus:[box-shadow:none]"
 			>
@@ -551,80 +594,83 @@
 				on:change={async () => {
 					sortAscending.set(!$sortAscending);
 					updateSearchQueryParams({ sortAscending: JSON.stringify(get(sortAscending)) });
-					updateEvent();
+					updateEvent("toggle sort direction");
 				}}
 			/>
 		</div>
 		<div class="flex flex-row mt-4">
 			<button
-				title="copies all entities as JSON"
+				title="copies all entities as JSON (sorted).&#13;Double click for YAML, single click for JSON"
 				on:click={() => {
-					const conf = confirm(`confirm copy of ${filteredData.length} entities?`);
-					if (!conf) {
-						return;
-					}
-					copy(
-						filteredData.map((i) => {
-							i.enabledWritable = undefined;
-							return i;
-						})
-					);
+					handleCopyWithDebounce('json', false);
+				}}
+				on:dblclick={() => {
+					doubleTriggered = true;
+					handleCopyWithDebounce('yaml', true);
 				}}
 				class="flex flex-row items-center dark:bg-stone-700 bg-stone-100 rounded p-1 pr-2 m-1"
 			>
 				<FileCopyOutline class="m-1" />
 				COPY ALL
 			</button>
-			<button
-				title="deletes currently filtered entites"
-				class="flex flex-row items-center dark:bg-rose-900 bg-stone-100 rounded p-1 pr-2 m-1"
-				on:click={async () => {
-					const confirmEach = confirm(`Do you want to confirm each entity's deletion separately?`);
-					const conf = confirm(
-						`this will delete all entities currently visible: ${filteredData.length} in total`
-					);
-					if (!conf) {
-						return;
-					}
-					const conf2 = confirm(
-						`think twice, this is the last chance to cancel!\n(refresh the page to stop the process)`
-					);
-					if (!conf2) {
-						return;
-					}
-					for (const entity of filteredData) {
-						if (confirmEach) {
-							const confirmEntity = confirm(
-								`Confirm deletion of:\n ${JSON.stringify(
-									{ name: entity.name, tags: entity.tags, id: entity.id },
-									undefined,
-									2
-								)}`
-							);
-							if (!confirmEntity) {
-								continue;
+			{#if get(preferences.showDeleteAllButton)}
+				<button
+					title="deletes currently filtered entites"
+					class="flex flex-row items-center dark:bg-rose-900 bg-stone-100 rounded p-1 pr-2 m-1"
+					on:click={async () => {
+						const conf = confirm(
+							`this will delete all entities currently visible: ${filteredData.length} in total`
+						);
+						if (!conf) {
+							return;
+						}
+						const confirmEach = confirm(
+							`delete without confirmation on each entity (Cancel)\nor confirm each entity's deletion individually (OK) ?`
+						);
+						const conf2 = confirm(
+							`think twice, this is the last chance to cancel!\n(refresh the page to stop the process)`
+						);
+						if (!conf2) {
+							return;
+						}
+						let anyDeleted = false;
+						for (const entity of filteredData) {
+							if (confirmEach) {
+								const confirmEntity = confirm(
+									`Confirm deletion of:\n ${JSON.stringify(
+										{ name: entity.name, tags: entity.tags, id: entity.id },
+										undefined,
+										2
+									)}`
+								);
+								if (!confirmEntity) {
+									continue;
+								}
+							}
+							const res = await (await apiService()).deleteRecord(type, entity.id);
+							if (res.ok) {
+								anyDeleted = true;
+								infoToast(
+									`deleted ${entity.name ?? ''}(${entity.id}) ${
+										filteredData.length - filteredData.indexOf(entity)
+									} remaining`
+								);
+							} else {
+								errorToast(`failed deletion of ${entity.name ?? entity.id}`);
+								errorToast(res.err ?? 'unknown error occured');
+								break;
 							}
 						}
-						const res = await (await apiService()).deleteRecord(type, entity.id);
-						if (res.ok) {
-							infoToast(
-								`deleted ${entity.name ?? ''}(${entity.id}) ${
-									filteredData.length - filteredData.indexOf(entity)
-								} remaining`
-							);
-						} else {
-							errorToast(`failed deletion of ${entity.name ?? entity.id}`);
-							errorToast(res.err ?? 'unknown error occured');
-							break;
+						if (anyDeleted) {
+							infoToast('deletion successfully finished! the page will be refreshed soon.');
+							dispatch('refresh');
 						}
-					}
-					infoToast('deletion successfully finished! the page will be refreshed soon.');
-					dispatch('refresh');
-				}}
-			>
-				<TrashBinOutline class="m-1" />
-				DELETE ALL
-			</button>
+					}}
+				>
+					<TrashBinOutline class="m-1" />
+					DELETE ALL
+				</button>
+			{/if}
 			<Button
 				color="alternative"
 				class="h-10 m-1"
@@ -814,10 +860,18 @@
 										<!-- svelte-ignore a11y-click-events-have-key-events -->
 										<!-- svelte-ignore a11y-no-noninteractive-element-interactions -->
 										<p
-											class="mr-2 cursor-pointer select-none overflow-hidden max-h-40 {field.includes("name") ? "text-[16px] font-extralight": ""}"
+											class="mr-2 cursor-pointer select-none overflow-hidden max-h-40 {field.includes(
+												'name'
+											)
+												? 'text-[16px] font-extralight'
+												: ''}"
 											title={field == 'name'
 												? `open ${item.name ?? ''} (${item.id})`
-												: `double-click to copy '${field}'\n${JSON.stringify(item[field], undefined, 2)} `}
+												: `double-click to copy '${field}'\n${JSON.stringify(
+														item[field],
+														undefined,
+														2
+													)} `}
 											on:dblclick={() => {
 												if (field == 'name') {
 													goto(`${base}/entity?type=${type}&id=${item.id}&prefix=${pathPrefix}`);

--- a/ui/src/lib/components/ArrayWrap.svelte
+++ b/ui/src/lib/components/ArrayWrap.svelte
@@ -721,7 +721,7 @@
 					? 'grid'
 					: 'hidden'}"
 			>
-				<pre class="language-json"><code bind:this={editorSyntax}></code></pre>
+				<pre class="language-json dark:bg-zinc-900"><code class="dark:bg-zinc-900" bind:this={editorSyntax}></code></pre>
 				<textarea
 					bind:this={editorWindow}
 					spellcheck="false"
@@ -1102,8 +1102,4 @@
 		padding-left: 75px;
 	}
 
-	code,
-	pre {
-		@apply dark:bg-zinc-900 bg-stone-800;
-	}
 </style>

--- a/ui/src/lib/components/ArrayWrap.svelte
+++ b/ui/src/lib/components/ArrayWrap.svelte
@@ -22,7 +22,7 @@
 	let useNewSearch = preferences?.useNewSearch;
 	const dispatch = createEventDispatcher();
 
-	export let dataRaw: ITooggleableEntityMaybe[];
+	export let dataRaw: Writable<ITooggleableEntityMaybe[]>;
 	export let type: string;
 	export let entity: IKongEntity | undefined = undefined;
 	export let pathPrefix: string | undefined = '';
@@ -35,7 +35,7 @@
 			displayedFields = displayedFields;
 		}
 	}
-
+	let isMounted = false;
 	let searchText = '';
 	interface FilteredEntity extends ITooggleableEntityMaybe {
 		enabledWritable: Writable<boolean>;
@@ -49,7 +49,7 @@
 	let debounce: number = DateTime.now().toUnixInteger();
 
 	let intervalsIterable: number[] = [];
-	let intervals = (dataRaw?.length ?? 0) / paginationSizeUi;
+	let intervals = ($dataRaw?.length ?? 0) / paginationSizeUi;
 
 	function calculatePagination() {
 		intervalsIterable = [];
@@ -122,15 +122,17 @@
 	let sortAscending = writable(entity?.sortAscending ?? false);
 
 	// this is to handle initial store event
-	function updateEventOnTrigger(v?: string) {
-		console.log(`page update triggered : ${v}`)
-		if (v) {
-			updateEvent("trigger update");
-		}
+	function updateEventOnTrigger(v: any[]) {
+		console.log(`page update triggered by data change items no: ${v.length}`);
+		updateEvent('trigger update');
 	}
 
-	function updateEvent(caller ="") {
-		console.log(`update called by '${caller}'`)
+	function updateEvent(caller = '') {
+		console.log(`update called by '${caller}'`);
+		if (!isMounted) {
+			console.log('not mounted yet, skipping update');
+			return;
+		}
 		const params = new URLSearchParams(window.location.search);
 		if (searchText.length == 0) {
 			searchText = params.get('search') ?? '';
@@ -172,10 +174,11 @@
 		});
 	}
 
-	triggerPageUpdate.subscribe(updateEventOnTrigger);
+	dataRaw.subscribe(updateEventOnTrigger);
 
 	onMount(() => {
-		updateEvent("on mount");
+		isMounted = true;
+		updateEvent('on mount');
 	});
 
 	async function disable(id: string, newEnabledValue: boolean) {
@@ -377,7 +380,7 @@
 		return groups;
 	}
 	function doSearch(input: string, arr: any[]) {
-		if (!dataRaw) {
+		if (!$dataRaw) {
 			return;
 		}
 		const orAndOr = getLogicalGroups(input);
@@ -409,8 +412,8 @@
 		if (searchText.length == 0) {
 			// we don't always sort on update event,
 			// because it could be searched, so we must sort when we know we're no longer searching
-			sort(dataRaw, `search ${type}`);
-			filteredData = dataRaw.map((i: any): FilteredEntity => {
+			sort(get(dataRaw), `search ${type}`);
+			filteredData = $dataRaw.map((i: any): FilteredEntity => {
 				if (i.enabled != undefined) {
 					i.enabledWritable = writable(i.enabled);
 				}
@@ -418,10 +421,10 @@
 			});
 		}
 		if (get(useNewSearch)) {
-			filteredData = doSearch(searchText, dataRaw) ?? [];
+			filteredData = doSearch(searchText, $dataRaw) ?? [];
 		} else {
 			const booleanAndSearch = searchText.split(/\s*&&\s*/);
-			filteredData = dataRaw.filter((item: any) => {
+			filteredData = $dataRaw.filter((item: any) => {
 				for (let condition of booleanAndSearch) {
 					const len = condition.split('.len == ');
 					if (len && len.length > 1 && Number.isInteger(+len[1]) && Array.isArray(item[len[0]])) {
@@ -546,7 +549,7 @@
 			<input
 				class="bg-transparent text-xl rounded-lg border-none outline-none focus:[box-shadow:none] ml-[-8px] w-full"
 				type="text"
-				disabled={!(dataRaw && dataRaw.length > 0)}
+				disabled={!($dataRaw && $dataRaw.length > 0)}
 				bind:value={searchText}
 				on:emptied={() => {
 					console.log('is empty');
@@ -576,11 +579,11 @@
 				bind:value={sortByField}
 				on:change={() => {
 					updateSearchQueryParams({ sortBy: sortByField });
-					updateEvent("select sort by");
+					updateEvent('select sort by');
 				}}
 				class="dark:bg-stone-700 shadow shadow-slate-600 h-6 p-0 max-w-36 pl-2 border-none rounded focus:border-none focus:[box-shadow:none]"
 			>
-				{#each Object.keys(dataRaw[0] ?? {}) as key}
+				{#each Object.keys($dataRaw[0] ?? {}) as key}
 					<option value={key} selected={key == sortByField}>{key}</option>
 				{/each}
 			</select>
@@ -594,7 +597,7 @@
 				on:change={async () => {
 					sortAscending.set(!$sortAscending);
 					updateSearchQueryParams({ sortAscending: JSON.stringify(get(sortAscending)) });
-					updateEvent("toggle sort direction");
+					updateEvent('toggle sort direction');
 				}}
 			/>
 		</div>
@@ -797,8 +800,8 @@
 				<tr>
 					<th><p class="pl-4">No.</p></th>
 					<th><p class="pl-4">Actions</p></th>
-					{#each displayedFields ?? Object.keys(dataRaw[0] ?? {}) as field}
-						{#if Object.keys(dataRaw[0] ?? {}).includes(field)}
+					{#each displayedFields ?? Object.keys($dataRaw[0] ?? {}) as field}
+						{#if Object.keys($dataRaw[0] ?? {}).includes(field)}
 							<th scope="col" class="pl-4"> {field} </th>
 						{/if}
 					{/each}
@@ -853,7 +856,7 @@
 							</div>
 						</td>
 
-						{#each displayedFields ?? Object.keys(dataRaw[0] ?? {}) as field}
+						{#each displayedFields ?? Object.keys($dataRaw[0] ?? {}) as field}
 							{#if Object.keys(item).includes(field)}
 								<td class="p-2">
 									<div class="flex flex-row items-center justify-between">

--- a/ui/src/lib/components/ArrayWrap.svelte
+++ b/ui/src/lib/components/ArrayWrap.svelte
@@ -66,16 +66,23 @@
 	}
 
 	let timeout: number | undefined = undefined;
-	function copyItemSingleDoubleClick(isDouble: boolean, data: any) {
+	function copyItemSingleDoubleClick(format: "yaml" | "json", data: any) {
 		data.enabledWritable = undefined;
-		setTimeout(() => {
-			if (!doubleTriggered) {
-				writeToClipboard(JSON.stringify(data, undefined, 2), ` JSON`);
-			} else if (isDouble) {
-				writeToClipboard(dump(data, yamlDumpOptions), ' YAML');
-				doubleTriggered = false;
-			}
-		}, 550);
+		if (timeout) {
+			clearTimeout(timeout);
+			timeout = undefined;
+		}
+		timeout = setTimeout(() => {
+			copyYamlOrJson(format, data)
+		}, 510);
+		// setTimeout(() => {
+		// 	if (!doubleTriggered) {
+		// 		writeToClipboard(JSON.stringify(data, undefined, 2), ` JSON`);
+		// 	} else if (isDouble) {
+		// 		writeToClipboard(dump(data, yamlDumpOptions), ' YAML');
+		// 		doubleTriggered = false;
+		// 	}
+		// }, 550);
 	}
 
 	let doubleTriggered = false;
@@ -100,6 +107,10 @@
 			i.enabledWritable = undefined;
 			return i;
 		});
+		copyYamlOrJson(format, data)
+	}
+
+	function copyYamlOrJson(format: 'yaml' | 'json', data: any) {
 		if (format == 'yaml') {
 			writeToClipboard(dump(data, yamlDumpOptions), ' YAML');
 		}
@@ -845,11 +856,11 @@
 									title={'copy (single click for JSON, double click for YAML) ' +
 										JSON.stringify(item, undefined, 2)}
 									on:click={() => {
-										copyItemSingleDoubleClick(false, item);
+										copyItemSingleDoubleClick("json", item);
 									}}
 									on:dblclick={() => {
 										doubleTriggered = true;
-										copyItemSingleDoubleClick(true, item);
+										copyItemSingleDoubleClick("yaml", item);
 									}}
 								>
 									<div

--- a/ui/src/lib/components/ArrayWrap.svelte
+++ b/ui/src/lib/components/ArrayWrap.svelte
@@ -65,6 +65,19 @@
 		intervalsIterable = intervalsIterable.slice(0, intervals);
 	}
 
+	let timeout: number | undefined = undefined;
+	function copyItemSingleDoubleClick(isDouble: boolean, data: any) {
+		data.enabledWritable = undefined;
+		setTimeout(() => {
+			if (!doubleTriggered) {
+				writeToClipboard(JSON.stringify(data, undefined, 2), ` JSON`);
+			} else if (isDouble) {
+				writeToClipboard(dump(data, yamlDumpOptions), ' YAML');
+				doubleTriggered = false;
+			}
+		}, 550);
+	}
+
 	let doubleTriggered = false;
 	function handleCopyWithDebounce(format: 'yaml' | 'json', isDouble: boolean) {
 		setTimeout(() => {
@@ -721,7 +734,9 @@
 					? 'grid'
 					: 'hidden'}"
 			>
-				<pre class="language-json dark:bg-zinc-900"><code class="dark:bg-zinc-900" bind:this={editorSyntax}></code></pre>
+				<pre class="language-json dark:bg-zinc-900"><code
+						class="dark:bg-zinc-900"
+						bind:this={editorSyntax}></code></pre>
 				<textarea
 					bind:this={editorWindow}
 					spellcheck="false"
@@ -827,9 +842,14 @@
 							<div class=" space-x-1 flex flex-row">
 								<button
 									class="h-8"
-									title={JSON.stringify(item, undefined, 2)}
+									title={'copy (single click for JSON, double click for YAML) ' +
+										JSON.stringify(item, undefined, 2)}
 									on:click={() => {
-										copy(item);
+										copyItemSingleDoubleClick(false, item);
+									}}
+									on:dblclick={() => {
+										doubleTriggered = true;
+										copyItemSingleDoubleClick(true, item);
 									}}
 								>
 									<div
@@ -1101,5 +1121,4 @@
 		padding: 10px;
 		padding-left: 75px;
 	}
-
 </style>

--- a/ui/src/lib/components/DarkToggle.svelte
+++ b/ui/src/lib/components/DarkToggle.svelte
@@ -94,7 +94,7 @@
 	{/if}
 	<div class="flex flex-row items-center">
 		<div class="cursor-pointer {div_class}" title="toggle dark mode" on:click={handleClick}>
-			<img src={logo} alt="bananaui logo" class="w-14 h-14 m-4 {$isDark ? 'invert' : ''}" />
+			<img src={logo} alt="bananaui logo" class="w-14 h-14 m-4  hover:rotate-3 hover:scale-[110%] {$isDark ? 'invert' : ''}" />
 		</div>
 		<h1 class="text-3xl font-bold">{staticConfig.name}</h1>
 	</div>

--- a/ui/src/lib/components/EntityPage.svelte
+++ b/ui/src/lib/components/EntityPage.svelte
@@ -32,7 +32,7 @@
 	import { base } from '$app/paths';
 	import Spinner from './Spinner.svelte';
 	import { preferences } from '$lib/stores';
-	import { get } from 'svelte/store';
+	import { get, writable, type Writable } from 'svelte/store';
 	import { icons } from '$lib/icons';
 	import Link from './Link.svelte';
 	import { dump } from 'js-yaml';
@@ -51,7 +51,7 @@
 	let currentEntity: IKongEntity | undefined;
 
 	interface IEntities extends IKongEntity {
-		data?: any[];
+		data?: Writable<any[]>;
 		entitySubPath: string;
 	}
 	let subEntities: IEntities[];
@@ -131,7 +131,7 @@
 					errorToast(`failed to load ${ent.name}`);
 					continue;
 				}
-				ent.data = res2.data?.data as any[];
+				ent.data = writable(res2.data?.data as any[]);
 				subEntities = subEntities;
 			}
 		}
@@ -332,7 +332,7 @@
 				? 'grid'
 				: 'hidden'}"
 		>
-			<pre class="language-json {highlightDisabled ? 'hidden' : ''}"><code bind:this={editorSyntax}
+			<pre class="language-json dark:bg-zinc-900 {highlightDisabled ? 'hidden' : ''}"><code class="dark:bg-zinc-900" bind:this={editorSyntax}
 				></code></pre>
 			<textarea
 				bind:this={editorWindow}
@@ -442,7 +442,7 @@
 							</Button>
 						</div>
 					</div>
-					{#if subEntity.data && subEntity.data.length > 0}
+					{#if subEntity.data && get(subEntity.data).length > 0}
 						<ArrayWrap
 							dataRaw={subEntity.data}
 							type={subEntity.name}
@@ -517,8 +517,4 @@
 		resize: none;
 	}
 
-	code,
-	pre {
-		@apply dark:bg-zinc-900 bg-stone-800;
-	}
 </style>

--- a/ui/src/lib/components/EntityPage.svelte
+++ b/ui/src/lib/components/EntityPage.svelte
@@ -8,7 +8,6 @@
 	import { goto } from '$app/navigation';
 	import { page, navigating, updated } from '$app/stores';
 	import { delay, getPluginPriorityMap, getPlugins, writeToClipboard } from '$lib/util';
-	import * as yaml from 'js-yaml';
 	import { addToast, confirmToast, errorToast, infoToast } from '$lib/toastStore';
 	import {
 		CaretDownOutline,
@@ -22,7 +21,13 @@
 		PaletteOutline,
 		TrashBinOutline
 	} from 'flowbite-svelte-icons';
-	import { fieldOrder, kongEntities, sortObjectFieldsByOrder, staticConfig } from '$lib/config';
+	import {
+		fieldOrder,
+		kongEntities,
+		sortObjectFieldsByOrder,
+		staticConfig,
+		yamlDumpOptions
+	} from '$lib/config';
 	import type { IKongEntity, IKongPlugin } from '$lib/types';
 	import { base } from '$app/paths';
 	import Spinner from './Spinner.svelte';
@@ -30,6 +35,8 @@
 	import { get } from 'svelte/store';
 	import { icons } from '$lib/icons';
 	import Link from './Link.svelte';
+	import { dump } from 'js-yaml';
+	import { DateTime } from 'luxon';
 
 	let stateJson = '';
 	let json = '';
@@ -54,21 +61,13 @@
 
 	let isMounted = false;
 
-	const yamlOptions: yaml.DumpOptions = {
-		noArrayIndent: true,
-		noRefs: true,
-		noCompatMode: true,
-		quotingType: '"',
-		lineWidth: 9999
-	};
-
 	let info: any;
 
 	onMount(async () => {
 		isMounted = true;
 		info = await getPluginPriorityMap();
 		await load();
-		triggerHighlight();
+		triggerHighlight('on mount');
 	});
 
 	function flipIsEdited() {
@@ -81,6 +80,10 @@
 			url.searchParams.delete('isEdited');
 		}
 		history.pushState(null, '', url);
+		json = stateJson;
+		if (isEdited) {
+			triggerHighlight('flip edit');
+		}
 	}
 
 	async function load() {
@@ -132,7 +135,7 @@
 				subEntities = subEntities;
 			}
 		}
-		triggerHighlight();
+		// triggerHighlight();
 
 		const plugins = await getPlugins(`/${entityType}/${id}`);
 		relevantPlugins = plugins;
@@ -177,7 +180,7 @@
 			return;
 		}
 		json = JSON.stringify(parsed, undefined, 2);
-		triggerHighlight();
+		triggerHighlight('format');
 		confirmToast(`json is valid`);
 	}
 	async function save() {
@@ -212,7 +215,7 @@
 	let editorSyntax: HTMLElement;
 
 	const max = 5;
-	async function triggerHighlight(selfCalled = 0) {
+	async function triggerHighlight(caller = '', selfCalled = 0) {
 		if (selfCalled > max) {
 			errorToast('highlight not triggered!');
 			return;
@@ -222,13 +225,13 @@
 
 		if (!editorSyntax) {
 			// needed as sometimes the function is called before the editor is added to the DOM
-			await delay(5);
-			await triggerHighlight(selfCalled + 1);
+			await delay(20);
+			await triggerHighlight(caller, selfCalled + 1);
 			return;
 		}
 		editorSyntax.textContent = json;
 		(globalThis as any).Prism.highlightElement(editorSyntax);
-		console.log(`Triggered on try ${selfCalled}`);
+		console.log(`prim highlight ok. try ${selfCalled} by '${caller}' at ${DateTime.now().toISO()}`);
 	}
 	let showPluginOrder = preferences.showPluginOrder;
 
@@ -248,7 +251,6 @@
 				class="h-10 m-1 focus:shadow-none"
 				on:click={() => {
 					flipIsEdited();
-					triggerHighlight();
 				}}
 			>
 				<FilePenOutline class="m-2" />edit
@@ -283,7 +285,7 @@
 					class="h-10 m-1"
 					title={stateJson}
 					on:click={() => {
-						writeToClipboard(yaml.dump(JSON.parse(stateJson), yamlOptions));
+						writeToClipboard(dump(JSON.parse(stateJson), yamlDumpOptions));
 					}}
 				>
 					<FileCopyAltOutline class="m-2" />
@@ -295,7 +297,7 @@
 					on:click={() => {
 						setTextareaHeight();
 						highlightDisabled = !highlightDisabled;
-						triggerHighlight();
+						// triggerHighlight();
 					}}
 					color="blue"
 					title="might be needed for json with long strings"
@@ -339,15 +341,16 @@
 				autocorrect="off"
 				autocapitalize="off"
 				translate="no"
-				class="relative {highlightDisabled ? "opacity-100": "opacity-10"}"
+				class="relative"
 				bind:value={json}
 				on:input={() => {
 					setTextareaHeight();
-					triggerHighlight();
+					triggerHighlight('on input to textarea');
 				}}
 			></textarea>
 		</div>
-		{#if !isEdited}
+		<div class="{isEdited? "hidden": ""}">
+
 			<TreeWrapper
 				{data}
 				rounded={false}
@@ -450,7 +453,7 @@
 					{/if}
 				{/each}
 			{/if}
-		{/if}
+		</div>
 	{:else}
 		<div class="flex flex-row items-center m-4">
 			<Spinner
@@ -480,7 +483,7 @@
 		overflow: hidden;
 		resize: none;
 		width: 100%;
-		@apply text-purple-400;
+		color: rgba(255, 255, 255, 0.1);
 	}
 
 	textarea,

--- a/ui/src/lib/components/EntityPage.svelte
+++ b/ui/src/lib/components/EntityPage.svelte
@@ -23,7 +23,6 @@
 	} from 'flowbite-svelte-icons';
 	import {
 		fieldOrder,
-		kongEntities,
 		sortObjectFieldsByOrder,
 		staticConfig,
 		yamlDumpOptions
@@ -113,10 +112,10 @@
 			json = JSON.stringify(data, undefined, 2);
 			stateJson = json;
 
-			currentEntity = kongEntities.find((ent) => ent.name == entityType);
+			currentEntity = get(preferences.kongEntities).find((ent) => ent.name == entityType);
 			subEntities = [];
 			for (const entity of currentEntity?.subEntities ?? []) {
-				const found = kongEntities.find((ent) => ent.name == entity);
+				const found = get(preferences.kongEntities).find((ent) => ent.name == entity);
 				if (!found) {
 					continue;
 				}

--- a/ui/src/lib/components/Preferences.svelte
+++ b/ui/src/lib/components/Preferences.svelte
@@ -7,9 +7,103 @@
 		setPreferences
 	} from '$lib/stores';
 	import { onMount } from 'svelte';
+	import type { IKongEntity } from '$lib/types';
+
+	export const kongEntities: IKongEntity[] = [
+		{
+			name: 'services',
+			displayedFields: ['enabled', 'name', 'host', 'id', 'updated_at'],
+			apiPath: 'services',
+			subEntities: ['plugins', 'routes'],
+			sortBy: 'updated_at',
+			sortAscending: false,
+			uiSpaceBefore: true,
+			defaultAddValue: {
+				url: 'https://example.com'
+			},
+			logo: 'globe'
+		},
+		{
+			name: 'routes',
+			displayedFields: ['methods', 'paths', 'service', 'updated_at'],
+			apiPath: 'routes',
+			subEntities: ['plugins'],
+			defaultAddValue: {
+				name: '',
+				paths: [],
+				methods: [],
+				strip_path: false
+			},
+			logo: 'shuffle'
+		},
+		{
+			name: 'plugins',
+			displayedFields: ['enabled', 'name', 'service', 'route', 'updated_at'],
+			apiPath: 'plugins',
+			logo: 'puzzle'
+		},
+		{
+			name: 'consumers',
+			displayedFields: ['username', 'custom_id', 'updated_at'],
+			apiPath: 'consumers',
+			defaultAddValue: {
+				username: '',
+				custom_id: ''
+			},
+			uiSpaceAfter: true,
+			logo: 'user_group'
+		},
+		{
+			name: 'certificates',
+			displayedFields: ['id', 'tags', 'updated_at'],
+			apiPath: 'certificates'
+		},
+		{
+			name: 'ca_certificates',
+			displayedFields: ['id', 'tags', 'updated_at'],
+			apiPath: 'ca_certificates'
+		},
+		{
+			name: 'upstreams',
+			displayedFields: ['name', 'updated_at'],
+			subEntities: ['targets'],
+			apiPath: 'upstreams',
+			defaultAddValue: {
+				name: ''
+			}
+		},
+		{
+			name: 'targets',
+			displayedFields: ['target', 'weight', 'updated_at'],
+			apiPath: 'targets',
+			showInMenu: false
+		},
+		{ name: 'keys', displayedFields: ['name', 'kid', 'updated_at'], apiPath: 'keys' },
+		{
+			name: 'key-sets',
+			displayedFields: ['name', 'id', 'updated_at'],
+			subEntities: ['keys'],
+			apiPath: 'key-sets',
+			defaultAddValue: { name: 'my_keyset_name' }
+		},
+		{ name: 'snis', displayedFields: undefined, apiPath: 'snis' },
+		{
+			name: 'vaults',
+			displayedFields: ['prefix', 'name', 'config', 'tags'],
+			apiPath: 'vaults'
+		},
+		{
+			name: 'dataplanes',
+			displayedFields: ['hostname', 'last_seen', 'labels', 'sync_status', 'version', 'config_hash'],
+			apiPath: 'clustering/data-planes',
+			uiSpaceAfter: true,
+			sortBy: 'last_seen',
+			uiSpaceBefore: true
+		}
+	];
 
 	const defaultPref: { [key: string]: any } = {
-		version: 5.3,
+		version: 5.4,
 		loadParentInfo: false,
 		paginationSizeUi: 20,
 		paginationSizeApi: 1000,
@@ -18,7 +112,8 @@
 		useEphemeralGetRequestsCache: true,
 		sortSearchedItemsDuringPaginationProcess: false,
 		showDeleteAllButton: false,
-		paginationRequestsDelayMs: 0
+		paginationRequestsDelayMs: 0,
+		kongEntities: kongEntities
 	};
 
 	const localCacheKey = 'preferences';

--- a/ui/src/lib/components/Preferences.svelte
+++ b/ui/src/lib/components/Preferences.svelte
@@ -9,7 +9,7 @@
 	import { onMount } from 'svelte';
 
 	const defaultPref: { [key: string]: any } = {
-		version: 5.1,
+		version: 5.3,
 		loadParentInfo: false,
 		paginationSizeUi: 20,
 		paginationSizeApi: 1000,
@@ -17,7 +17,8 @@
 		useNewSearch: false,
 		useEphemeralGetRequestsCache: true,
 		sortSearchedItemsDuringPaginationProcess: false,
-		showDeleteAllButton: false
+		showDeleteAllButton: false,
+		paginationRequestsDelayMs: 0
 	};
 
 	const localCacheKey = 'preferences';

--- a/ui/src/lib/components/Preferences.svelte
+++ b/ui/src/lib/components/Preferences.svelte
@@ -9,13 +9,15 @@
 	import { onMount } from 'svelte';
 
 	const defaultPref: { [key: string]: any } = {
-		version: 4,
+		version: 5.1,
 		loadParentInfo: false,
 		paginationSizeUi: 20,
 		paginationSizeApi: 1000,
 		showPluginOrder: false,
 		useNewSearch: false,
 		useEphemeralGetRequestsCache: true,
+		sortSearchedItemsDuringPaginationProcess: false,
+		showDeleteAllButton: false
 	};
 
 	const localCacheKey = 'preferences';

--- a/ui/src/lib/components/SideBar.svelte
+++ b/ui/src/lib/components/SideBar.svelte
@@ -30,10 +30,9 @@
 		}
 	];
 	import { onMount } from 'svelte';
-	import { kongEntities } from '$lib/config';
 	import { capitalizeFirstLetter } from '$lib/util';
 	import { base } from '$app/paths';
-	import { config, userToken } from '$lib/stores';
+	import { config, preferences, userToken } from '$lib/stores';
 	import { get } from 'svelte/store';
 	import { icons } from '$lib/icons';
 
@@ -60,7 +59,7 @@
 
 	onMount(() => {
 		mounted = true;
-		const entities = kongEntities
+		const entities = get(preferences.kongEntities)
 			.filter((i) => {
 				if (i.showInMenu === undefined) {
 					return true;

--- a/ui/src/lib/components/treeWrapper.svelte
+++ b/ui/src/lib/components/treeWrapper.svelte
@@ -1,15 +1,16 @@
 <script lang="ts">
 	import { goto } from '$app/navigation';
-	import { dateFields, kongEntities } from '$lib/config';
+	import { dateFields } from '$lib/config';
 	import { writeToClipboard } from '$lib/util';
 	import JSONTree from 'svelte-json-tree';
 	import { DateTime } from 'luxon';
 	import { base } from '$app/paths';
-	import { writable } from 'svelte/store';
+	import { get, writable } from 'svelte/store';
 	import Toggle from './Toggle.svelte';
 	import { createEventDispatcher, onMount } from 'svelte';
 	import { confirmToast, infoToast } from '$lib/toastStore';
 	import { apiService } from '$lib/requests';
+	import { preferences } from '$lib/stores';
 	export let data: any;
 	export let expandLevel = 0;
 	export let allowCopy = true;
@@ -70,7 +71,7 @@
 									);
 								}}
 							>
-								{#if data[key] && Object.keys(data[key]).includes('id') && kongEntities.find((i) => i.apiPath == `${key}s`)}
+								{#if data[key] && Object.keys(data[key]).includes('id') && get(preferences.kongEntities).find((i) => i.apiPath == `${key}s`)}
 									<!-- svelte-ignore a11y-click-events-have-key-events -->
 									<!-- svelte-ignore a11y-no-static-element-interactions -->
 									<a href="{base}/entity?type={key}s&id={data[key].id}" on:click|preventDefault>

--- a/ui/src/lib/config.ts
+++ b/ui/src/lib/config.ts
@@ -1,5 +1,3 @@
-import { get } from 'svelte/store';
-import { preferences } from './stores';
 import type { DumpOptions } from 'js-yaml';
 
 export const staticConfig = {
@@ -87,14 +85,3 @@ export function sortObjectFieldsByOrder<T extends AnyObject>(
 	// Reconstruct the object
 	return Object.fromEntries(sortedEntries) as T;
 }
-
-export const oldPrefs = {
-	copyElementOnSingleElementArray: {
-		type: 'boolean',
-		default: true
-	},
-	showSelfLinkOnSubEntities: {
-		type: 'boolean',
-		default: false
-	}
-};

--- a/ui/src/lib/config.ts
+++ b/ui/src/lib/config.ts
@@ -1,13 +1,22 @@
 import { get } from 'svelte/store';
 import { preferences } from './stores';
 import type { IKongEntity } from './types';
+import type { DumpOptions } from 'js-yaml';
 
 export const staticConfig = {
 	autoLoginDelayMs: 100,
 	name: 'Banana UI'
 };
 
-export const paginationAwaitBetweenPages = 0;
+export const yamlDumpOptions: DumpOptions = {
+		noArrayIndent: true,
+		noRefs: true,
+		noCompatMode: true,
+		quotingType: '"',
+		lineWidth: 9999
+	};
+
+export const paginationAwaitBetweenPages = 100;
 
 export const dateFields = ['created_at', 'updated_at', 'last_seen'];
 export const fieldOrder = [

--- a/ui/src/lib/config.ts
+++ b/ui/src/lib/config.ts
@@ -2,7 +2,7 @@ import type { DumpOptions } from 'js-yaml';
 
 export const staticConfig = {
 	autoLoginDelayMs: 100,
-	name: 'Banana UI'
+	name: 'BananaUI'
 };
 
 export const yamlDumpOptions: DumpOptions = {

--- a/ui/src/lib/config.ts
+++ b/ui/src/lib/config.ts
@@ -1,6 +1,5 @@
 import { get } from 'svelte/store';
 import { preferences } from './stores';
-import type { IKongEntity } from './types';
 import type { DumpOptions } from 'js-yaml';
 
 export const staticConfig = {
@@ -88,105 +87,6 @@ export function sortObjectFieldsByOrder<T extends AnyObject>(
 	// Reconstruct the object
 	return Object.fromEntries(sortedEntries) as T;
 }
-
-export const kongEntities: IKongEntity[] = [
-	{
-		name: 'services',
-		displayedFields: [
-			'enabled',
-			'name',
-			'host',
-			'id',
-			'updated_at'
-		],
-		apiPath: 'services',
-		subEntities: [
-			'plugins',
-			'routes',
-		],
-		sortBy: 'updated_at',
-		sortAscending: false,
-		uiSpaceBefore: true,
-		defaultAddValue: {
-			url: "https://example.com"
-		},
-		logo: 'globe'
-	},
-	{
-		name: 'routes',
-		displayedFields: ['methods', 'paths', 'service', 'updated_at'],
-		apiPath: 'routes',
-		subEntities: ['plugins'],
-		defaultAddValue: {
-			name: "",
-			paths: [],
-			methods: [],
-			strip_path: false
-		},
-		logo: 'shuffle'
-	},
-	{
-		name: 'plugins',
-		displayedFields: [
-			'enabled',
-			'name',
-			'service', 'route',
-			'updated_at'],
-		apiPath: 'plugins',
-		logo: 'puzzle'
-	},
-	{
-		name: 'consumers', displayedFields: ['username', 'custom_id', 'updated_at'], apiPath: 'consumers',
-		defaultAddValue: {
-			username: "",
-			custom_id: ""
-		},
-		uiSpaceAfter: true,
-		logo: "user_group"
-	},
-	{
-		name: 'certificates', displayedFields: ['id', 'tags', 'updated_at'], apiPath: 'certificates',
-	},
-	{
-		name: 'ca_certificates', displayedFields: ['id', 'tags', 'updated_at'], apiPath: 'ca_certificates',
-	},
-	{
-		name: 'upstreams', displayedFields: ['name', 'updated_at'],
-		subEntities: ['targets'],
-		apiPath: 'upstreams',
-		defaultAddValue: {
-			name: ""
-		}
-	},
-	{ name: 'targets', displayedFields: ['target', 'weight', 'updated_at'], apiPath: 'targets', showInMenu: false },
-	{ name: 'keys', displayedFields: ['name', 'kid', 'updated_at'], apiPath: 'keys' },
-	{
-		name: 'key-sets',
-		displayedFields: ['name', 'id', 'updated_at'],
-		subEntities: ['keys'],
-		apiPath: 'key-sets',
-		defaultAddValue: { name: 'my_keyset_name' }
-	},
-	{ name: 'snis', displayedFields: undefined, apiPath: 'snis' },
-	{
-		name: 'vaults',
-		displayedFields: [
-			"prefix",
-			"name",
-			"config",
-			"tags"
-		],
-		apiPath: 'vaults'
-	},
-	{
-		name: 'dataplanes',
-		displayedFields: ['hostname', 'last_seen', 'labels', 'sync_status', 'version', 'config_hash'],
-		apiPath: 'clustering/data-planes',
-		uiSpaceAfter: true,
-		sortBy: 'last_seen',
-		uiSpaceBefore: true
-	}
-];
 
 export const oldPrefs = {
 	copyElementOnSingleElementArray: {

--- a/ui/src/lib/config.ts
+++ b/ui/src/lib/config.ts
@@ -16,8 +16,6 @@ export const yamlDumpOptions: DumpOptions = {
 		lineWidth: 9999
 	};
 
-export const paginationAwaitBetweenPages = 100;
-
 export const dateFields = ['created_at', 'updated_at', 'last_seen'];
 export const fieldOrder = [
 	// common

--- a/ui/src/lib/requests.ts
+++ b/ui/src/lib/requests.ts
@@ -72,6 +72,7 @@ async function requestWithResponseBodyCached<ResType, ErrType = void>(
 		const res = await requestWithResponseBody(url, method, body, headers)
 		if (res.ok) {
 			cacheMap[cacheKey ?? url] = res
+			return res as ResWrapped<ResType, ErrType>
 		}
 	}
 	return requestWithResponseBody(url, method, body, headers)

--- a/ui/src/lib/stores.ts
+++ b/ui/src/lib/stores.ts
@@ -1,5 +1,5 @@
 import { get, writable, type Writable } from 'svelte/store';
-import type { IConfig, IConfigWrap } from './types';
+import type { IConfig, IConfigWrap, IKongEntity } from './types';
 import { DateTime } from 'luxon';
 
 export const isDark = writable(0);
@@ -9,10 +9,13 @@ export const config: Writable<IConfigWrap | undefined | null> = writable(undefin
 export function setPreferences(prefs: any) {
 	preferences = prefs
 }
-export let preferences: { [key: string]: Writable<any> } = {}
+export let preferences: {
+	kongEntities: Writable<IKongEntity[]>
+} & { [key: string]: Writable<any> } = {
+	kongEntities: writable([])
+}
 
-export function savePreferences()
-{
+export function savePreferences() {
 	localStorage.setItem('preferences', getPreferencesAsJson());
 }
 export function getPreferencesAsJson(): string {

--- a/ui/src/lib/stores.ts
+++ b/ui/src/lib/stores.ts
@@ -5,7 +5,6 @@ import { DateTime } from 'luxon';
 export const isDark = writable(0);
 export const userToken: Writable<{ token: string, expires: number } | undefined> = writable(undefined);
 export const config: Writable<IConfigWrap | undefined | null> = writable(undefined);
-export const triggerPageUpdate: Writable<string> = writable();
 
 export function setPreferences(prefs: any) {
 	preferences = prefs

--- a/ui/src/lib/stores.ts
+++ b/ui/src/lib/stores.ts
@@ -5,17 +5,12 @@ import { DateTime } from 'luxon';
 export const isDark = writable(0);
 export const userToken: Writable<{ token: string, expires: number } | undefined> = writable(undefined);
 export const config: Writable<IConfigWrap | undefined | null> = writable(undefined);
-export const triggerPageUpdate: Writable<string> = writable(
-	DateTime.now().toUnixInteger().toString()
-);
+export const triggerPageUpdate: Writable<string> = writable();
 
 export function setPreferences(prefs: any) {
 	preferences = prefs
 }
 export let preferences: { [key: string]: Writable<any> } = {}
-// export function getPreferences(): { [key: string]: Writable<any> }  {
-// 	return
-// }
 
 export function savePreferences()
 {

--- a/ui/src/lib/util.ts
+++ b/ui/src/lib/util.ts
@@ -19,6 +19,38 @@ export const writeToClipboard = (
 	});
 };
 
+export function debouncedCall<T extends (...args: any[]) => any>(fn: T, delay: number) {
+	let timeoutId: number | null = null;
+
+	const debounced = function (...args: Parameters<T>): void {
+		if (timeoutId) {
+			clearTimeout(timeoutId)
+		}
+		timeoutId = setTimeout(() => {
+			fn(...args)
+		}, delay);
+	}
+
+	debounced.cancel = () => {
+		if (timeoutId) {
+			clearTimeout(timeoutId);
+			timeoutId = null;
+		}
+	};
+
+	debounced.flush = (...args: Parameters<T>) => {
+			clearTimeout(timeoutId);
+			timeoutId = null;
+		}
+		fn(...args);
+	};
+
+	return debounced as typeof debounced & {
+		cancel: () => void,
+		flush: (...args: Parameters<T>) => void,
+	}
+}
+
 export function capitalizeFirstLetter(string?: string) {
 	if (!string) return "";
 	return string.charAt(0).toUpperCase() + string.slice(1);

--- a/ui/src/lib/util.ts
+++ b/ui/src/lib/util.ts
@@ -39,6 +39,7 @@ export function debouncedCall<T extends (...args: any[]) => any>(fn: T, delay: n
 	};
 
 	debounced.flush = (...args: Parameters<T>) => {
+		if (timeoutId) {
 			clearTimeout(timeoutId);
 			timeoutId = null;
 		}

--- a/ui/src/lib/util.ts
+++ b/ui/src/lib/util.ts
@@ -9,8 +9,9 @@ export const delay = (delayInms: number) => {
 
 export const writeToClipboard = (
 	text: string,
+	extraNotifyText = "",
 	onSuccess: (value: void) => void = () => {
-		confirmToast('copied');
+		confirmToast(`copied${extraNotifyText}`);
 	}
 ) => {
 	navigator.clipboard.writeText(text).then(onSuccess, () => {

--- a/ui/src/routes/entities/+page.svelte
+++ b/ui/src/routes/entities/+page.svelte
@@ -7,7 +7,6 @@
 	import { apiService, cacheMap, type ResWrapped } from '$lib/requests';
 	import { onMount } from 'svelte';
 	import { page } from '$app/stores';
-	import { kongEntities } from '$lib/config';
 	import { capitalizeFirstLetter, delay } from '$lib/util';
 	import { base } from '$app/paths';
 	import { DateTime } from 'luxon';
@@ -47,7 +46,7 @@
 		pathPrefix = params.get('prefix') ?? '';
 
 		try {
-			kongEntity = kongEntities.find((i) => i.name == entity);
+			kongEntity = get(preferences.kongEntities).find((i) => i.name == entity);
 			if (!kongEntity) {
 				return;
 			}

--- a/ui/src/routes/entities/+page.svelte
+++ b/ui/src/routes/entities/+page.svelte
@@ -3,7 +3,6 @@
 	import type { IKongEntity } from '$lib/types';
 	import { CirclePlusOutline, RefreshOutline } from 'flowbite-svelte-icons';
 	import { goto } from '$app/navigation';
-	import { triggerPageUpdate } from '$lib/stores';
 	import { staticConfig } from '$lib/config';
 	import ArrayWrap from '$lib/components/ArrayWrap.svelte';
 	import { apiService, cacheMap, type ResWrapped } from '$lib/requests';
@@ -61,7 +60,6 @@
 				return;
 			}
 			data.set(res.data.data);
-			triggerPageUpdate.set('init.load+' + entity + DateTime.now().toMillis());
 			var loopStarted = loadStart;
 			await delay(paginationAwaitBetweenPages);
 

--- a/ui/src/routes/entities/+page.svelte
+++ b/ui/src/routes/entities/+page.svelte
@@ -43,7 +43,6 @@
 		}
 		const params = new URLSearchParams(window.location.search);
 		loadStart = DateTime.now();
-		const oldEntity = entity;
 		entity = params.get('type') ?? 'none';
 		pathPrefix = params.get('prefix') ?? '';
 
@@ -99,7 +98,7 @@
 	<title>{capitalizeFirstLetter(entity)} {entity ? '|' : ''} {staticConfig.name}</title>
 </svelte:head>
 
-{#if $data}
+{#if entity}
 	<div class="flex flex-col m-4 mb-3 font-light text-2xl">
 		<div class="flex flex-row mb-2 h-10">
 			<Button

--- a/ui/src/routes/entities/+page.svelte
+++ b/ui/src/routes/entities/+page.svelte
@@ -16,24 +16,32 @@
 	import { addToast, errorToast, infoToast } from '$lib/toastStore';
 	import { Button } from 'flowbite-svelte';
 	import Spinner from '$lib/components/Spinner.svelte';
+	import { writable, get } from 'svelte/store';
 
-	let data: any | undefined;
+	let data = writable([]);
 	let entity: string;
 	let kongEntity: IKongEntity | undefined;
 	let isMounted = false;
 	let pathPrefix: string = '';
 
 	page.subscribe((val) => {
-		load();
+		if (!isMounted) {
+			return;
+		}
+		load('page changed');
 	});
 
+	data.subscribe(v => {
+		console.log(v)
+	})
 	onMount(() => {
 		isMounted = true;
-		load();
+		load('on mount');
 	});
 	let loadStart: DateTime | undefined;
 
-	async function load(isRefresh = false) {
+	async function load(caller = '', isRefresh = false) {
+		console.log(`load called by '${caller}'`);
 		if (!isMounted) {
 			return;
 		}
@@ -42,12 +50,7 @@
 		const oldEntity = entity;
 		entity = params.get('type') ?? 'none';
 		pathPrefix = params.get('prefix') ?? '';
-		let willTriggerUpdate = false;
 
-		if (oldEntity != entity) {
-			data = undefined;
-			willTriggerUpdate = true;
-		}
 		try {
 			kongEntity = kongEntities.find((i) => i.name == entity);
 			if (!kongEntity) {
@@ -60,7 +63,8 @@
 				errorToast(`failed to fetch the ${entity}. ${res.err} (${res.code})`);
 				return;
 			}
-			data = res.data.data;
+			data.set(res.data.data);
+			triggerPageUpdate.set('init.load+' + entity + DateTime.now().toMillis());
 			var loopStarted = loadStart;
 			await delay(paginationAwaitBetweenPages);
 
@@ -70,16 +74,15 @@
 					break;
 				}
 				if (res.ok) {
-					data = data.concat(res.data.data);
-					if (willTriggerUpdate) {
-					}
+					data.set(get(data).concat(res.data.data));
+					triggerPageUpdate.set('bulk+' + entity + DateTime.now().toMillis());
 				}
 				await delay(paginationAwaitBetweenPages);
 			}
 			// dataplanes don't have a page of their own.
 			// populating the cache to fake as if the request went through
-			if (kongEntity.apiPath === 'clustering/data-planes') {
-				for (const dp of data) {
+			if (kongEntity && kongEntity.apiPath === 'clustering/data-planes') {
+				for (const dp of $data) {
 					const res: ResWrapped<any, any> = {
 						code: 200,
 						ok: true,
@@ -87,8 +90,8 @@
 					};
 					cacheMap[`/dataplanes/${dp.id}`] = res;
 				}
+				triggerPageUpdate.set(entity + DateTime.now().toMillis());
 			}
-			triggerPageUpdate.set(entity + DateTime.now().toMillis());
 			if (isRefresh) {
 				infoToast('refresh finished!');
 			}
@@ -103,13 +106,13 @@
 	<title>{capitalizeFirstLetter(entity)} {entity ? '|' : ''} {staticConfig.name}</title>
 </svelte:head>
 
-{#if data}
+{#if $data}
 	<div class="flex flex-col m-4 mb-3 font-light text-2xl">
 		<div class="flex flex-row mb-2 h-10">
 			<Button
 				class=" flex flex-row mr-2  items-center bg-green-500 dark:bg-green-700"
 				on:click={() => {
-					load(true);
+					load('user clicked', true);
 					infoToast('refresh started!');
 				}}
 			>
@@ -132,10 +135,10 @@
 		</div>
 	</div>
 	<ArrayWrap
-		dataRaw={data}
+		dataRaw={$data}
 		type={entity}
 		entity={kongEntity}
-		on:refresh={async () => await load(true)}
+		on:refresh={async () => await load('arraywrap requested refresh', true)}
 	></ArrayWrap>
 {:else}
 	<div class="flex flex-row items-center p-5 h-full w-full">

--- a/ui/src/routes/entities/+page.svelte
+++ b/ui/src/routes/entities/+page.svelte
@@ -16,9 +16,9 @@
 	import { addToast, errorToast, infoToast } from '$lib/toastStore';
 	import { Button } from 'flowbite-svelte';
 	import Spinner from '$lib/components/Spinner.svelte';
-	import { writable, get } from 'svelte/store';
+	import { writable, get, type Writable } from 'svelte/store';
 
-	let data = writable([]);
+	let data: Writable<any[]> = writable([]);
 	let entity: string;
 	let kongEntity: IKongEntity | undefined;
 	let isMounted = false;
@@ -31,9 +31,6 @@
 		load('page changed');
 	});
 
-	data.subscribe(v => {
-		console.log(v)
-	})
 	onMount(() => {
 		isMounted = true;
 		load('on mount');
@@ -75,7 +72,6 @@
 				}
 				if (res.ok) {
 					data.set(get(data).concat(res.data.data));
-					triggerPageUpdate.set('bulk+' + entity + DateTime.now().toMillis());
 				}
 				await delay(paginationAwaitBetweenPages);
 			}
@@ -90,7 +86,6 @@
 					};
 					cacheMap[`/dataplanes/${dp.id}`] = res;
 				}
-				triggerPageUpdate.set(entity + DateTime.now().toMillis());
 			}
 			if (isRefresh) {
 				infoToast('refresh finished!');
@@ -135,10 +130,10 @@
 		</div>
 	</div>
 	<ArrayWrap
-		dataRaw={$data}
+		dataRaw={data}
 		type={entity}
 		entity={kongEntity}
-		on:refresh={async () => await load('arraywrap requested refresh', true)}
+		on:refresh={async () => await load('array wrap requested refresh', true)}
 	></ArrayWrap>
 {:else}
 	<div class="flex flex-row items-center p-5 h-full w-full">

--- a/ui/src/routes/entities/+page.svelte
+++ b/ui/src/routes/entities/+page.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-	import { paginationAwaitBetweenPages } from '$lib/config';
 	import type { IKongEntity } from '$lib/types';
 	import { CirclePlusOutline, RefreshOutline } from 'flowbite-svelte-icons';
 	import { goto } from '$app/navigation';
@@ -16,6 +15,7 @@
 	import { Button } from 'flowbite-svelte';
 	import Spinner from '$lib/components/Spinner.svelte';
 	import { writable, get, type Writable } from 'svelte/store';
+	import { preferences } from '$lib/stores';
 
 	let data: Writable<any[]> = writable([]);
 	let entity: string;
@@ -61,7 +61,7 @@
 			}
 			data.set(res.data.data);
 			var loopStarted = loadStart;
-			await delay(paginationAwaitBetweenPages);
+			await delay(get(preferences.paginationRequestsDelayMs));
 
 			while (res.data.next) {
 				res = await (await apiService()).request<any>(res.data.next ?? '', undefined, undefined);
@@ -71,7 +71,7 @@
 				if (res.ok) {
 					data.set(get(data).concat(res.data.data));
 				}
-				await delay(paginationAwaitBetweenPages);
+				await delay(get(preferences.paginationRequestsDelayMs));
 			}
 			// dataplanes don't have a page of their own.
 			// populating the cache to fake as if the request went through

--- a/ui/src/routes/preferences/+page.svelte
+++ b/ui/src/routes/preferences/+page.svelte
@@ -64,7 +64,7 @@
 </div>
 <div class="dark:border-stone-700">
 	<div class="editor dark:bg-[#1E2021] w-full min-h-[30vh] line-numbers">
-		<pre class="language-json"><code bind:this={editorSyntax}></code></pre>
+		<pre class="language-json dark:bg-zinc-900"><code class="dark:bg-zinc-900" bind:this={editorSyntax}></code></pre>
 		<textarea
 			bind:this={editorWindow}
 			spellcheck="false"
@@ -129,8 +129,4 @@
 		padding-left: 75px;
 	}
 
-	code,
-	pre {
-		@apply dark:bg-zinc-900 bg-stone-800;
-	}
 </style>

--- a/ui/src/routes/styles.css
+++ b/ui/src/routes/styles.css
@@ -28,7 +28,7 @@ body {
 }
 
 .http-method{
-	@apply text-white px-3 text-sm;
+	@apply text-white px-2 py-1 text-sm;
 }
 
 .method-get {

--- a/ui/src/routes/styles.css
+++ b/ui/src/routes/styles.css
@@ -28,29 +28,29 @@ body {
 }
 
 .http-method{
-	@apply text-white;
+	@apply text-white px-3 text-sm;
 }
 
 .method-get {
-	@apply bg-emerald-400 dark:bg-emerald-900;
+	@apply bg-emerald-400 dark:bg-emerald-600;
 }
 
 .method-post {
-	@apply bg-indigo-400 dark:bg-indigo-900;
+	@apply bg-blue-400 dark:bg-blue-600;
 }
 
 .method-put {
-	@apply bg-orange-400 dark:bg-orange-900;
+	@apply bg-orange-400 dark:bg-orange-500;
 }
 
 .method-patch {
-	@apply bg-yellow-400 dark:bg-yellow-900;
+	@apply bg-yellow-400 dark:bg-yellow-400;
 }
 
 .method-delete {
-	@apply bg-red-400 dark:bg-red-900;
+	@apply bg-red-400 dark:bg-red-600;
 }
 
 .method-options {
-	@apply bg-cyan-400 dark:bg-cyan-900;
+	@apply bg-cyan-400 dark:bg-cyan-600;
 }


### PR DESCRIPTION
# changelog:

- kong entities are now user configurable. this allows to select the displayed fields, and their order.
- allow both YAML and JSON copy of all entities and individual entities. single click for JSON, double click for YAML.
- dark mode switch now animated
- pagination calls delay is now user configurable.
- items are now updated as the pagination is in process, but not sorted if any text is searched (to avoid jumps of items if existing items are already looked at)
- fixed a bug where trying to update then cancelling maintained the state.
- deleteAll button now only displayed if enabled in preferences.
- fixed a bug where the caching feature caused double requests on cache miss.
- http method div made bigger and dark mode colors were made lighter

## technical changelog:
- debounce wrapper implemented -> cleaner future debounces
- fixed svelte css errors, caused by taliwind modifiers like `dark:`, by moving them to the element class.
- stores are now passed to the array wrap components, makes for easier update detection, manual page update trigger removed.